### PR TITLE
Python 3 StringIO won't work with flask send content as a buffer. We …

### DIFF
--- a/corr-cloud/cloud/views/user_cloud.py
+++ b/corr-cloud/cloud/views/user_cloud.py
@@ -21,7 +21,7 @@ from hurry.filesize import size
 import hashlib
 import os
 import mimetypes
-from io import StringIO
+from io import BytesIO
 
 @app.route(CLOUD_URL + '/public/user/register', methods=['GET','POST','PUT','UPDATE','DELETE','POST'])
 @crossdomain(fk=fk, app=app, origin='*')


### PR DESCRIPTION
…have to use ByteIO now.